### PR TITLE
Remove deprectiated adminmedia templatetags (Django-1.5)

### DIFF
--- a/polymorphic_tree/templates/admin/polymorphic_tree/change_form.html
+++ b/polymorphic_tree/templates/admin/polymorphic_tree/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_modify adminmedia polymorphic_admin_tags polymorphic_tree_admin_tags %}
+{% load i18n admin_modify polymorphic_admin_tags polymorphic_tree_admin_tags %}
 
 {# Add tree levels to polymorphic breadcrumb #}
 {% block breadcrumbs %}{% if not is_popup %}{% breadcrumb_scope base_opts %}


### PR DESCRIPTION
This allows django-polymorphic-tree to work on Django 1.5
