### PR TITLE
Do not refetch moved after moved.move_to.

### DIFF
--- a/polymorphic_tree/admin/parentadmin.py
+++ b/polymorphic_tree/admin/parentadmin.py
@@ -205,8 +205,6 @@ class PolymorphicMPTTParentModelAdmin(PolymorphicParentModelAdmin, MPTTModelAdmi
 
         # Some packages depend on calling .save() or post_save signal after updating a model.
         # This is required by django-fluent-pages for example to update the URL caches.
-        # Make sure the updated version (with new parent_id/lft/rgt fields is fetched)
-        moved = self.model.objects.get(pk=moved_id)
         moved.save()
 
         # Report back to client.


### PR DESCRIPTION
Also fixes issue with children objects not knowing thier original parent
after move.
