### PR TITLE
Setting the manager explicitly

### DIFF
--- a/polymorphic_tree/models.py
+++ b/polymorphic_tree/models.py
@@ -77,7 +77,7 @@ class PolymorphicMPTTModel(with_metaclass(PolymorphicMPTTModelBase, MPTTModel, P
     can_have_children = True
 
     # Django fields
-    _default_manager = PolymorphicMPTTModelManager()
+    objects = PolymorphicMPTTModelManager()
 
     class Meta:
         abstract = True


### PR DESCRIPTION
Due to [the way](https://github.com/chrisglass/django_polymorphic/blob/master/polymorphic/base.py) Django Polymorphic sets the `PolymorphicManager`, we need to override their manager explicitly in order to make it work the way it is [supposed to](https://github.com/edoburu/django-polymorphic-tree/blob/2439464/polymorphic_tree/models.py#L80). I haven't found any other way of doing this.

What do you think?
