### PR TITLE
Support for UUID primary key field

### DIFF
--- a/polymorphic_tree/admin/parentadmin.py
+++ b/polymorphic_tree/admin/parentadmin.py
@@ -189,10 +189,13 @@ class PolymorphicMPTTParentModelAdmin(PolymorphicParentModelAdmin, MPTTModelAdmi
 
             position = request.POST['position']
 
-            if isinstance(moved_id, integer_types) and isinstance(target_id, integer_types):
-                previous_parent_id = int(request.POST['previous_parent_id']) or None
+            if request.POST.get('previous_parent_id'):
+                if isinstance(moved_id, integer_types) and isinstance(target_id, integer_types):
+                    previous_parent_id = int(request.POST['previous_parent_id'])
+                else:
+                    previous_parent_id = request.POST['previous_parent_id']
             else:
-                previous_parent_id = request.POST['previous_parent_id'] or None
+                previous_parent_id = None
 
             # Not using .non_polymorphic() so all models are downcasted to the derived model.
             # This causes the signal below to be emitted from the proper class as well.

--- a/polymorphic_tree/models.py
+++ b/polymorphic_tree/models.py
@@ -1,6 +1,7 @@
 """
 Model that inherits from both Polymorphic and MPTT.
 """
+import uuid
 import django
 from future.utils import with_metaclass
 from django.core.exceptions import ValidationError
@@ -52,7 +53,7 @@ class PolymorphicTreeForeignKey(TreeForeignKey):
     def _validate_parent(self, parent, model_instance):
         if not parent:
             return
-        elif isinstance(parent, integer_types):
+        elif isinstance(parent, integer_types) or isinstance(parent, uuid.UUID):
             # TODO: Improve this code, it's a bit of a hack now because the base model is not known in the NodeTypePool.
             base_model = _get_base_polymorphic_model(model_instance.__class__)
 

--- a/polymorphic_tree/templates/admin/polymorphic_tree/jstree_list_results.html
+++ b/polymorphic_tree/templates/admin/polymorphic_tree/jstree_list_results.html
@@ -47,7 +47,7 @@
    */
 
   var data = [{% adminlist_recursetree cl %}{% with is_leaf=node.is_leaf_node %}
-    {id: {{ node.pk }}, classes: 'nodetype-{{ node|real_model_name|lower }}', can_have_children: {{ node.can_have_children|yesno:'true,false' }}, label: '<div class="col-primary{% if is_leaf %} leaf{% endif %}"><div class="col first-column"><a href="{{ change_url }}"{% if cl.is_popup %} onclick="opener.dismissRelatedLookupPopup(window, {{ node.pk }}); return false;"{% endif %}>{{ first_column|escapejs }}</a></div></div>{% if other_columns %}<div class="col-metadata">{% for name, repr in other_columns %}<div class="col col-{{ name }}">{{ repr|escapejs }}</div>{% endfor %}</div>{% endif %}'{% if not is_leaf %},
+    {id: '{{ node.pk }}', classes: 'nodetype-{{ node|real_model_name|lower }}', can_have_children: {{ node.can_have_children|yesno:'true,false' }}, label: '<div class="col-primary{% if is_leaf %} leaf{% endif %}"><div class="col first-column"><a href="{{ change_url }}"{% if cl.is_popup %} onclick="opener.dismissRelatedLookupPopup(window, {{ node.pk }}); return false;"{% endif %}>{{ first_column|escapejs }}</a></div></div>{% if other_columns %}<div class="col-metadata">{% for name, repr in other_columns %}<div class="col col-{{ name }}">{{ repr|escapejs }}</div>{% endfor %}</div>{% endif %}'{% if not is_leaf %},
      children: [ {{ children }}
      ]{% endif %}},{% endwith %}{% endadminlist_recursetree %}
     null  // for MSIE
@@ -88,9 +88,9 @@
       url: '{{ cl.model_admin.api_node_moved_view_url }}',
       dataType: 'json',
       data: {
-        'moved_id': parseInt(move_info.moved_node.id),
-        'target_id': parseInt(move_info.target_node.id),
-        'previous_parent_id': parseInt(move_info.previous_parent.id || 0),
+        'moved_id': move_info.moved_node.id,
+        'target_id': move_info.target_node.id,
+        'previous_parent_id': move_info.previous_parent.id,
         'position': move_info.position,
         'csrfmiddlewaretoken': '{{ csrf_token }}'
       },


### PR DESCRIPTION
It looks like models that use `UUIDField` as the primary key are not supported because of various places where an `id` is being cast to an `int`. Would it make sense to cast to a pass a string from the client and parse it on the server as an int or leave it as a string if there's a `ValueError`?

I'm willing to refactor and clean things up if this is a possible path for our solution, right now this is more like patchwork for getting support for `UUID` primary keys on my own application. And if it's worth going this direction, I'll squash and rebase my commits into a single commit for this pull request.

Any thoughts would be appreciated, thanks! 👍 
