### PR TITLE
Fix parent field name different from 'parent'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 docs/_build/
 *.sqlite3
 .tox
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,26 @@ python:
 - '2.7'
 - '3.3'
 - '3.4'
+- '3.5'
+- '3.6'
 env:
-- PACKAGES="django>=1.6,<1.7 django-mptt<0.8"
 - PACKAGES="django>=1.7,<1.8 django-mptt<0.8"
 - PACKAGES="django>=1.8,<1.9"
 - PACKAGES="django>=1.9,<1.10"
 - PACKAGES="django>=1.10,<1.11"
 matrix:
+  include:
+  - python: '2.7'
+    env: PACKAGES="mock==2.0.0"
   exclude:
   - python: '3.3'
     env: PACKAGES="django>=1.9,<1.10"
   - python: '3.3'
     env: PACKAGES="django>=1.10,<1.11"
+  - python: '3.5'
+    env: PACKAGES="django>=1.7,<1.8"
+  - python: '3.6'
+    env: PACKAGES="django>=1.7,<1.8"
 before_install:
 - pip install codecov
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
   - python: '3.3'
     env: PACKAGES="django>=1.10,<1.11"
   - python: '3.5'
-    env: PACKAGES="django>=1.7,<1.8"
+    env: PACKAGES="django>=1.7,<1.8 django-mptt<0.8"
   - python: '3.6'
-    env: PACKAGES="django>=1.7,<1.8"
+    env: PACKAGES="django>=1.7,<1.8 django-mptt<0.8"
 before_install:
 - pip install codecov
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ env:
 - PACKAGES="django>=1.9,<1.10"
 - PACKAGES="django>=1.10,<1.11"
 matrix:
-  include:
-  - python: '2.7'
-    env: PACKAGES="mock==2.0.0"
   exclude:
   - python: '3.3'
     env: PACKAGES="django>=1.9,<1.10"

--- a/README.rst
+++ b/README.rst
@@ -179,15 +179,24 @@ To run the included test suite, execute::
 
     ./runtests.py
 
-To test support for multiple Python and Django versions, run tox from the repository root::
+To test support for multiple Python and Django versions, you need to follow steps below:
+
+ * install project requirements in virtual environment
+ * install python 2.7, 3.3, 3.4, 3.5, 3.6 python versions through pyenv (See pyenv (Linux) or Homebrew (Mac OS X).)
+ * create .python-version file and add full list of installed versions with which project have to be tested, example::
+
+    2.6.9
+    2.7.13
+    3.3.6
+    3.4.5
+    3.5.2
+    3.6.0
+ * run tox from the repository root::
 
     pip install tox
     tox
 
-The Python versions need to be installed at your system.  See pyenv (Linux) or Homebrew (Mac OS X).
-
-Python 2.6, 2.7, and 3.3 are the currently supported versions.
-
+Python 2.7, 3.3, 3.4, 3.5 and 3.6 and django 1.7, 1.8, 1.9 and 1.10 are the currently supported versions.
 
 Todo
 ----

--- a/README.rst
+++ b/README.rst
@@ -181,9 +181,9 @@ To run the included test suite, execute::
 
 To test support for multiple Python and Django versions, you need to follow steps below:
 
- * install project requirements in virtual environment
- * install python 2.7, 3.3, 3.4, 3.5, 3.6 python versions through pyenv (See pyenv (Linux) or Homebrew (Mac OS X).)
- * create .python-version file and add full list of installed versions with which project have to be tested, example::
+* install project requirements in virtual environment
+* install python 2.7, 3.3, 3.4, 3.5, 3.6 python versions through pyenv (See pyenv (Linux) or Homebrew (Mac OS X).)
+* create .python-version file and add full list of installed versions with which project have to be tested, example::
 
     2.6.9
     2.7.13
@@ -191,7 +191,7 @@ To test support for multiple Python and Django versions, you need to follow step
     3.4.5
     3.5.2
     3.6.0
- * run tox from the repository root::
+* run tox from the repository root::
 
     pip install tox
     tox

--- a/README.rst
+++ b/README.rst
@@ -172,6 +172,40 @@ The ``child_models`` attribute defines which admin interface is loaded for the *
 The list view is still rendered by the parent admin.
 
 
+Validation
+^^^^^^^^^^
+
+When drag-n-drop nodes in tree in admin, ``clean``/``full_clean`` method is not called. To implement validation, you
+should override ``can_be_moved`` model method. Method have to return ``True`` if nothing happens and moving is allowing.
+Otherwise, ``can_be_moved`` have to raise ``ValidationError`` or ``InvalidMove`` from ``mptt.exceptions``
+
+.. code:: python
+
+    class Participant(PolymorphicMPTTModel):
+        conference = models.ForeignKey(Conference)
+        invited_by = PolymorphicTreeForeignKey(
+            'self',
+            null=True,
+            blank=True,
+            related_name='invited',
+            verbose_name=_('Invited')
+        )
+
+        def clean(self):
+            if self.participant:
+                if self.conference != self.manager.conference:
+                    raise ValidationError({
+                        'invited_by': _(
+                            'Participants have to be from the same '
+                            'conference'
+                        )
+                    })
+
+        def can_be_moved(self, target):
+            self.invited_by = target
+            self.clean()
+            return True
+
 Tests
 -----
 

--- a/polymorphic_tree/admin/parentadmin.py
+++ b/polymorphic_tree/admin/parentadmin.py
@@ -198,7 +198,7 @@ class PolymorphicMPTTParentModelAdmin(PolymorphicParentModelAdmin, MPTTModelAdmi
                 'moved_id': moved_id,
                 'error': _(u'Cannot place \u2018{0}\u2019 below \u2018{1}\u2019; a {2} does not allow children!').format(moved, target, target._meta.verbose_name)
             }), content_type='application/json', status=409)  # Conflict
-        if moved.parent_id != previous_parent_id:
+        if getattr(moved, '{}_id'.format(moved._mptt_meta.parent_attr)) != previous_parent_id:
             return HttpResponse(json.dumps({
                 'action': 'reload',
                 'error': 'Client seems to be out-of-sync, please reload!'

--- a/polymorphic_tree/models.py
+++ b/polymorphic_tree/models.py
@@ -111,6 +111,20 @@ class PolymorphicMPTTModel(with_metaclass(PolymorphicMPTTModelBase, MPTTModel, P
         """
         return self.get_ancestors(ascending=ascending, include_self=include_self).instance_of(model)
 
+    def can_be_moved(self, target):
+        """Can move be finished
+
+        Method have to be redefined in inherited model to define cases when
+        node can be moved. If method is not redefined moving always allows
+
+        To deny move, this method have to be raised ``ValidationError`` or
+        ``InvalidMove`` from ``mptt.exceptions``
+
+        Args:
+            target (PolymorphicMPTTModel): future parent of node
+        """
+        return True
+
 
 if django.VERSION < (1,7):
     # South integration

--- a/polymorphic_tree/models.py
+++ b/polymorphic_tree/models.py
@@ -123,7 +123,7 @@ class PolymorphicMPTTModel(with_metaclass(PolymorphicMPTTModelBase, MPTTModel, P
         Args:
             target (PolymorphicMPTTModel): future parent of node
         """
-        return True
+        pass
 
 
 if django.VERSION < (1,7):

--- a/polymorphic_tree/tests/admin.py
+++ b/polymorphic_tree/tests/admin.py
@@ -1,0 +1,25 @@
+from polymorphic_tree.admin import (PolymorphicMPTTChildModelAdmin,
+                                    PolymorphicMPTTParentModelAdmin)
+from polymorphic_tree.tests.models import ModelWithCustomParentName
+
+
+class BaseChildAdmin(PolymorphicMPTTChildModelAdmin):
+    """Test child admin"""
+    GENERAL_FIELDSET = (None, {
+        'fields': ('chief', 'field5'),
+    })
+
+    base_model = ModelWithCustomParentName
+    base_fieldsets = (
+        GENERAL_FIELDSET,
+    )
+
+
+class TreeNodeParentAdmin(PolymorphicMPTTParentModelAdmin):
+    """Test parent admin"""
+    base_model = ModelWithCustomParentName
+    child_models = (
+        (ModelWithCustomParentName, BaseChildAdmin),
+    )
+
+    list_display = ('field5', 'actions_column',)

--- a/polymorphic_tree/tests/models.py
+++ b/polymorphic_tree/tests/models.py
@@ -46,3 +46,27 @@ class ModelX(Base):
 
 class ModelY(Base):
     field_y = models.CharField(max_length=10)
+
+
+class ModelWithCustomParentName(PolymorphicMPTTModel):
+    """Model with custom parent name
+
+    A model where ``PolymorphicTreeForeignKey`` attribute has not ``parent``
+    name, but ``chief``
+
+    Attributes:
+        chief (ModelWithCustomParentName): parent
+        field5 (str): test field
+    """
+    chief = PolymorphicTreeForeignKey('self',
+                                      blank=True,
+                                      null=True,
+                                      related_name='subordinate',
+                                      verbose_name='Chief')
+    field5 = models.CharField(max_length=10)
+
+    class MPTTMeta:
+        parent_attr = 'chief'
+
+    def __str__(self):
+        return self.field5

--- a/polymorphic_tree/tests/models.py
+++ b/polymorphic_tree/tests/models.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
+from mptt.exceptions import InvalidMove
 
 from polymorphic.showfields import ShowFieldContent
 from polymorphic_tree.models import PolymorphicMPTTModel, PolymorphicTreeForeignKey
@@ -76,9 +77,10 @@ class ModelWithCustomParentName(PolymorphicMPTTModel):
 class ModelWithValidation(PolymorphicMPTTModel):
     """Model with custom validation
 
-    A model with redefined ``clean`` method
+    A model with redefined ``clean`` and ``can_be_moved`` methods
 
     ``clean`` method always raises ``ValidationError``
+    ``can_be_moved`` always calls ``clean``
 
     Attributes:
         parent (ModelWithValidation): parent
@@ -88,8 +90,7 @@ class ModelWithValidation(PolymorphicMPTTModel):
     parent = PolymorphicTreeForeignKey('self',
                                        blank=True,
                                        null=True,
-                                       related_name='children',
-                                       verbose_name='Chief')
+                                       related_name='children')
 
     field6 = models.CharField(max_length=10)
 
@@ -99,3 +100,29 @@ class ModelWithValidation(PolymorphicMPTTModel):
             'parent': 'There is something with parent field'
         })
 
+    def can_be_moved(self, target):
+        """Execute ``clean``"""
+        self.clean()
+
+
+class ModelWithInvalidMove(PolymorphicMPTTModel):
+    """Model with custom validation
+
+    A model with redefined only ``can_be_moved`` method which always raises
+    ``InvalidMove``
+
+    Attributes:
+        parent (ModelWithValidation): parent
+        field7 (str): test field
+    """
+
+    parent = PolymorphicTreeForeignKey('self',
+                                       blank=True,
+                                       null=True,
+                                       related_name='children')
+
+    field7 = models.CharField(max_length=10)
+
+    def can_be_moved(self, target):
+        """Raise ``InvalidMove``"""
+        raise InvalidMove('Invalid move')

--- a/polymorphic_tree/tests/models.py
+++ b/polymorphic_tree/tests/models.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.db import models
 
 from polymorphic.showfields import ShowFieldContent
@@ -70,3 +71,31 @@ class ModelWithCustomParentName(PolymorphicMPTTModel):
 
     def __str__(self):
         return self.field5
+
+
+class ModelWithValidation(PolymorphicMPTTModel):
+    """Model with custom validation
+
+    A model with redefined ``clean`` method
+
+    ``clean`` method always raises ``ValidationError``
+
+    Attributes:
+        parent (ModelWithValidation): parent
+        field6 (str): test field
+    """
+
+    parent = PolymorphicTreeForeignKey('self',
+                                       blank=True,
+                                       null=True,
+                                       related_name='children',
+                                       verbose_name='Chief')
+
+    field6 = models.CharField(max_length=10)
+
+    def clean(self):
+        """Raise validation error"""
+        raise ValidationError({
+            'parent': 'There is something with parent field'
+        })
+

--- a/polymorphic_tree/tests/test_admin.py
+++ b/polymorphic_tree/tests/test_admin.py
@@ -1,10 +1,16 @@
 from unittest import TestCase
-from unittest.mock import MagicMock
+
+import sys
 
 from django.contrib.admin import AdminSite
 
 from polymorphic_tree.tests.admin import TreeNodeParentAdmin
 from polymorphic_tree.tests.models import ModelWithCustomParentName
+
+if sys.version_info[0] == 3:
+    from unittest.mock import MagicMock
+else:
+    from mock import MagicMock
 
 
 class PolymorphicAdminTests(TestCase):
@@ -33,5 +39,7 @@ class PolymorphicAdminTests(TestCase):
             'position': 'inside'
         }
         self.parent_admin.api_node_moved_view(request)
-        self.child2.refresh_from_db()
+        # Analog of self.child2.refresh_from_db()
+        # This hack used for django 1.7 support
+        self.child2 = ModelWithCustomParentName.objects.get(pk=self.child2.pk)
         self.assertEqual(self.child2.chief, self.child1)

--- a/polymorphic_tree/tests/test_admin.py
+++ b/polymorphic_tree/tests/test_admin.py
@@ -5,7 +5,8 @@ from django.contrib.admin import AdminSite
 
 from polymorphic_tree.admin.parentadmin import get_permission_codename
 from polymorphic_tree.tests.admin import TreeNodeParentAdmin
-from polymorphic_tree.tests.models import Model2A, ModelWithCustomParentName
+from polymorphic_tree.tests.models import Model2A, ModelWithCustomParentName, \
+    ModelWithValidation
 
 if sys.version_info[0] == 3:
     from unittest.mock import MagicMock
@@ -29,6 +30,23 @@ class PolymorphicAdminTests(TestCase):
         self.parent_admin = TreeNodeParentAdmin(ModelWithCustomParentName,
                                                 AdminSite())
 
+        self.parent_with_validation = ModelWithValidation.objects.create(
+            field6='parent'
+        )
+        self.child1_with_validation = ModelWithValidation.objects.create(
+            field6='child1',
+            parent=self.parent_with_validation
+        )
+        self.child2_with_validation = ModelWithValidation.objects.create(
+            field6='child2',
+            parent=self.parent_with_validation
+        )
+
+        self.parent_admin_with_validation = TreeNodeParentAdmin(
+            ModelWithValidation,
+            AdminSite()
+        )
+
     def test_make_child2_child_child1(self):
         """Make ``self.child2`` child of ``self.child1``"""
         request = MagicMock()
@@ -43,6 +61,22 @@ class PolymorphicAdminTests(TestCase):
         # This hack used for django 1.7 support
         self.child2 = ModelWithCustomParentName.objects.get(pk=self.child2.pk)
         self.assertEqual(self.child2.chief, self.child1)
+
+    def test_validation_error(self):
+        """Ensure that if move can't be performed due validation error, move
+        can't be performed and json error returned
+        """
+        request = MagicMock()
+        request.POST = {
+            'moved_id': self.child2_with_validation.id,
+            'target_id': self.child1_with_validation.id,
+            'previous_parent_id': self.parent_with_validation.id,
+            'position': 'inside'
+        }
+
+        resp = self.parent_admin_with_validation.api_node_moved_view(request)
+
+        self.assertEqual(resp.status_code, 400)
 
     def test_get_permission_codename(self):
         # This is to test whether our function works in older Django versions.

--- a/polymorphic_tree/tests/test_admin.py
+++ b/polymorphic_tree/tests/test_admin.py
@@ -1,0 +1,37 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from django.contrib.admin import AdminSite
+
+from polymorphic_tree.tests.admin import TreeNodeParentAdmin
+from polymorphic_tree.tests.models import ModelWithCustomParentName
+
+
+class PolymorphicAdminTests(TestCase):
+    """Tests for admin"""
+
+    def setUp(self):
+        self.parent = ModelWithCustomParentName.objects.create(field5='parent')
+        self.child1 = ModelWithCustomParentName.objects.create(
+            field5='child1',
+            chief=self.parent
+        )
+        self.child2 = ModelWithCustomParentName.objects.create(
+            field5='child2',
+            chief=self.parent
+        )
+        self.parent_admin = TreeNodeParentAdmin(ModelWithCustomParentName,
+                                                AdminSite())
+
+    def test_make_child2_child_child1(self):
+        """Make ``self.child2`` child of ``self.child1``"""
+        request = MagicMock()
+        request.POST = {
+            'moved_id': self.child2.id,
+            'target_id': self.child1.id,
+            'previous_parent_id': self.parent.id,
+            'position': 'inside'
+        }
+        self.parent_admin.api_node_moved_view(request)
+        self.child2.refresh_from_db()
+        self.assertEqual(self.child2.chief, self.child1)

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ deps =
     django19: django-mptt >= 0.8.0
     django110: Django >= 1.10, < 1.11
     django110: django-mptt >= 0.8.6
+    py26: mock
+    py27: mock
     django-dev: https://github.com/django/django/tarball/master
 commands=
     python runtests.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,15 @@
 [tox]
 envlist=
-    py26-django{16},
-    py27-django{16,17,18,19,110},
-    py33-django{16,17,18},
-    py34-django{16,17,18,19,110},
-    py35-django{19}
-    # py33-django-dev,
-    docs,
+    py27-django{17,18,19,110},
+    py33-django{17,18},
+    py34-django{17,18,19,110},
+    py35-django{18,19,110},
+    py36-django{18,19,110},
+;    docs,
 
 [testenv]
 deps =
     django-polymorphic >= 0.8.1
-    django16: Django >= 1.6, < 1.7
-    django16: django-mptt < 0.8.0
     django17: Django >= 1.7, < 1.8
     django17: django-mptt < 0.8.0
     django18: Django >= 1.8, < 1.9
@@ -23,11 +20,12 @@ deps =
     django110: django-mptt >= 0.8.6
     py26: mock
     py27: mock
-    django-dev: https://github.com/django/django/tarball/master
+;    django-dev: https://github.com/django/django/tarball/master
 commands=
     python runtests.py
 
-[testenv:docs]
-deps=Sphinx
-changedir = docs
-commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+; Have no configuration for sphinx in project repository
+;[testenv:docs]
+;deps=Sphinx
+;changedir = docs
+;commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
If PolymorphicTreeForeignKey field name has name which different from 'parent' there was an error in admin
Added test for case above
Actualized tox and travis configs
Added step-by-step instruction to readme how to run tests
Adjusted supported version list in readme