### PR TITLE
Allow child type validation in memory

### DIFF
--- a/polymorphic_tree/models.py
+++ b/polymorphic_tree/models.py
@@ -174,6 +174,11 @@ class PolymorphicMPTTModel(with_metaclass(PolymorphicMPTTModelBase, MPTTModel, P
             return False
 
         child_types = self.get_child_types()
+
+        # this allows tree validation to occur in the event the child model is not
+	# yet created in db (ie. when django admin tries to validate)
+        child.pre_save_polymorphic()
+
         return not child_types or child.polymorphic_ctype_id in child_types
 
     def validate_move(self, target, position='first-child'):

--- a/polymorphic_tree/tests/models.py
+++ b/polymorphic_tree/tests/models.py
@@ -145,3 +145,8 @@ class ModelMustBeChildRoot(PolymorphicMPTTModel):
 
 class ModelMustBeChild(ModelMustBeChildRoot):
     can_be_root = False
+
+class ModelRestrictedChildren(Base):
+    child_types = [
+        ModelX,
+    ]

--- a/polymorphic_tree/tests/test_models.py
+++ b/polymorphic_tree/tests/test_models.py
@@ -35,6 +35,7 @@ class PolymorphicTests(TestCase):
         test_custom_pk()
         test_fix_getattribute()
         test_parent_link_and_related_name()
+        test_child_type_validation_in_memory()
 
     """
 
@@ -226,6 +227,21 @@ class MPTTTests(TestCase):
         self.assertTrue(grandchild.is_child_node())
         self.assertTrue(grandchild.is_leaf_node())
         self.assertFalse(grandchild.is_root_node())
+
+    def test_child_type_validation_in_memory(self):
+        root_node = ModelRestrictedChildren.objects.create(field_b='root')
+
+        valid_child = ModelX(field_b='valid_child', field_x='ModelX', parent=root_node)
+        valid_child.clean()
+
+        with self.assertRaises(ValidationError) as context:
+            invalid_child = ModelY(field_b='invalid_child', field_y='ModelY', parent=root_node)
+            invalid_child.clean()
+
+        self.assertTrue('a model restricted children does not allow model y as a child!'
+         in context.exception.args[0]['parent'])
+
+
 
     def test_tree_manager(self):
         # Having the tree manager correct is absolutely essential,


### PR DESCRIPTION
This PR introduces the ability to validate a child type against the parent prior to the child being saved in the database.

With restricted `child_types` set, django admin would not allow you to add a valid child type because it tries to validate the object before creating it in the db and the `polymorphic_ctype_id` is not set to be able to answer the question. 

This change simply calls the available `pre_save_polymorphic()` method to set the id in memory prior to the check.

Test added to expose issue.

