### PR TITLE
Add support for Django3

### DIFF
--- a/polymorphic_tree/models.py
+++ b/polymorphic_tree/models.py
@@ -2,12 +2,12 @@
 Model that inherits from both Polymorphic and MPTT.
 """
 import uuid
+from six import integer_types, string_types
 
 import django
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.utils.encoding import force_text
-from django.utils.six import integer_types, string_types
 from django.utils.translation import ugettext_lazy as _
 from future.utils import with_metaclass
 from mptt.exceptions import InvalidMove

--- a/runtests.py
+++ b/runtests.py
@@ -54,6 +54,7 @@ if not settings.configured:
                         'django.template.context_processors.request',
                         'django.template.context_processors.static',
                         'django.contrib.auth.context_processors.auth',
+                        'django.contrib.messages.context_processors.messages',
                     ),
                 },
             },
@@ -75,6 +76,15 @@ if not settings.configured:
             'django.contrib.auth.middleware.AuthenticationMiddleware',
             'django.contrib.messages.middleware.MessageMiddleware',
             'django.middleware.locale.LocaleMiddleware',  # / will be redirected to /<locale>/
+        ),
+        MIDDLEWARE=(
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'django.contrib.messages.middleware.MessageMiddleware',
+            'django.middleware.locale.LocaleMiddleware',  # / will be redirected to /<locale>/
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'django.contrib.messages.middleware.MessageMiddleware',
+            'django.contrib.sessions.middleware.SessionMiddleware',
         ),
         ROOT_URLCONF = 'example.urls',
         TEST_RUNNER = 'django.test.runner.DiscoverRunner',

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'django-mptt>=0.8.0',
         'django-tag-parser>=2.1',
         'future>=0.12.2',
+        'six>=1.13.0',
     ],
     requires=[
         'Django (>=1.8)',

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist=
 
 [testenv]
 deps =
+    six >= 1.13.0
     django-polymorphic >= 2.0
     django-mptt >= 0.9.0
     django111: Django >= 1.11, < 1.12


### PR DESCRIPTION
Directly import six library as it is not included anymore in Django utils.